### PR TITLE
feat: add scaled positions

### DIFF
--- a/src/components/RoomBox/index.js
+++ b/src/components/RoomBox/index.js
@@ -21,6 +21,7 @@ import LeaveRoomButton from 'components/LeaveRoomButton';
 import YoutubePlayer from 'components/YoutubePlayer';
 import ViewOnlyModal from 'components/ViewOnlyModal';
 import { AnimatePresence } from 'framer-motion';
+import { useWindowSize } from 'hooks/useWindowSize';
 
 function RoomBox(props) {
   const socket = useContext(SocketContext);
@@ -42,6 +43,7 @@ function RoomBox(props) {
   const { status, data } = currentRoom;
   const toast = useToast();
   const history = useHistory();
+  const windowSize = useWindowSize();
   const roomId = props.roomId;
 
   const [userReaction, setUserReaction] = useState('');
@@ -298,7 +300,10 @@ function RoomBox(props) {
             profilePicture={val.profilePicture}
             prefix={val.prefix ?? ''}
             username={val.username}
-            position={val.position}
+            position={{
+              x: Math.floor(val.position.x * windowSize.width),
+              y: Math.floor(val.position.y * windowSize.height),
+            }}
             type={val.type}
             reaction={val.reaction !== '' ? val.reaction : null}
           />

--- a/src/hooks/useWindowSize.js
+++ b/src/hooks/useWindowSize.js
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+
+export const useWindowSize = () => {
+  // Initialize state with undefined width/height so server and client renders match
+  // Learn more here: https://joshwcomeau.com/react/the-perils-of-rehydration/
+  const [windowSize, setWindowSize] = useState({
+    width: undefined,
+    height: undefined,
+  });
+
+  useEffect(() => {
+    // Handler to call on window resize
+    const handleResize = () => {
+      // Set window width/height to state
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+
+    // Add event listener
+    window.addEventListener('resize', handleResize);
+
+    // Call handler right away so state gets updated with initial window size
+    handleResize();
+
+    // Remove event listener on cleanup
+    return () => window.removeEventListener('resize', handleResize);
+  }, []); // Empty array ensures that effect is only run on mount
+
+  return windowSize;
+};


### PR DESCRIPTION
Implements #2 
- Use client window size to compute scaled and unscaled positions
- Added new hook `useWindowSize` to get window size, responds to resize

Caveats:
- on resize, only `Bubble` component will change position, `ClientBubble` will not change position because in #3 we stopped using state to control the `ClientBubble`'s position.